### PR TITLE
Convert keywords into a list of strings

### DIFF
--- a/profile.json
+++ b/profile.json
@@ -32,39 +32,17 @@
   "jobTitle": "Infrastructure as Code Consultant",
   "title": "IAC consultant.",
   "keywords": [
-    {
-      "name": "Terraform"
-    },
-    {
-      "name": "terragrunt"
-    },
-    {
-      "name": "IAC"
-    },
-    {
-      "name": "linux"
-    },
-    {
-      "name": "docker"
-    },
-    {
-      "name": "kubernetes"
-    },
-    {
-      "name": "aws"
-    },
-    {
-      "name": "devops"
-    },
-    {
-      "name": "cicd"
-    },
-    {
-      "name": "github actions"
-    },
-    {
-      "name": "golang"
-    }
+    "Terraform",
+    "terragrunt",
+    "IAC",
+    "linux",
+    "docker",
+    "kubernetes",
+    "aws",
+    "devops",
+    "cicd",
+    "github actions",
+    "golang"
   ],
   "longSummary": "I have been working with production infrastructure for about 25 years. My primary interests are implementing DevOps pipelines with Infrastructure as Code. I love working with AWS Terraform/Terragrunt, Kubernetes and Golang.",
   "name": "Cruftyold Sysadmin",


### PR DESCRIPTION
Fixes #6

Convert the `keywords` array in `profile.json` to a list of strings, removing the `name` key from each object.

* Replace each object in the `keywords` array with its corresponding string value.
* Remove the `name` key from each object in the `keywords` array.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cruftyoldsysadmin/profiles.dev/pull/7?shareId=7e85afda-0076-467f-86cb-099a9280341e).